### PR TITLE
list_box's margins in gtk3 as in gtk2 

### DIFF
--- a/shoes/native/gtk.c
+++ b/shoes/native/gtk.c
@@ -1389,8 +1389,11 @@ SHOES_CONTROL_REF
 shoes_native_list_box(VALUE self, shoes_canvas *canvas, shoes_place *place, VALUE attr, char *msg)
 {
 #ifdef GTK3
+  /*get bottom margin : following macro gives us bmargin (also lmargin,tmargin,rmargin)*/
+  ATTR_MARGINS(attr, 2, canvas);
+  
   //SHOES_CONTROL_REF ref = gtk_combo_box_text_new();
-  SHOES_CONTROL_REF ref = gtk_combo_box_text_alt_new(attr);
+  SHOES_CONTROL_REF ref = gtk_combo_box_text_alt_new(attr, bmargin);
 #else
   SHOES_CONTROL_REF ref = gtk_combo_box_new_text();
 #endif

--- a/shoes/native/gtkcomboboxtextalt.c
+++ b/shoes/native/gtkcomboboxtextalt.c
@@ -138,7 +138,7 @@ gtk_combo_box_text_alt_init(GtkComboBoxText_Alt *comboboxtextAlt)
 
 /* Return a new GtkComboBoxText_Alt cast to a GtkWidget */
 GtkWidget *
-gtk_combo_box_text_alt_new(VALUE attribs)
+gtk_combo_box_text_alt_new(VALUE attribs, int bottom_margin)
 {
   GtkWidget *ref;
   ref = GTK_WIDGET(g_object_new(gtk_combo_box_text_alt_get_type(), NULL));
@@ -147,11 +147,11 @@ gtk_combo_box_text_alt_new(VALUE attribs)
   int w = 160, h = 30;
   if (RTEST(ATTR(attribs, width))) w = NUM2INT(ATTR(attribs, width));
   if (RTEST(ATTR(attribs, height))) h = NUM2INT(ATTR(attribs, height));
-  
+
   //GtkCellArea *area = gtk_cell_layout_get_area((GtkCellLayout *)ref);
   GList *renderers = gtk_cell_layout_get_cells((GtkCellLayout *)ref);
   GtkCellRendererText *cell = g_list_first(renderers)->data;    //only one renderer
-  gtk_cell_renderer_set_fixed_size((GtkCellRenderer *)cell, w, h);
+  gtk_cell_renderer_set_fixed_size((GtkCellRenderer *)cell, w, h-bottom_margin*2);
   g_object_set((GtkCellRenderer *)cell, "ellipsize", PANGO_ELLIPSIZE_END, NULL);
   
   return ref;
@@ -216,6 +216,8 @@ gtk_combo_box_text_alt_get_preferred_height_for_width(GtkWidget *widget,
     
     GtkRequisition min_size, nat_size;
     gtk_cell_renderer_get_preferred_size(cell, widget, &min_size, &nat_size);
+    gint cell_width, cell_height;
+    gtk_cell_renderer_get_fixed_size(cell, &cell_width, &cell_height);
     
     gint xpad, ypad;
     gtk_cell_renderer_get_padding(cell, &xpad, &ypad);

--- a/shoes/native/gtkcomboboxtextalt.c
+++ b/shoes/native/gtkcomboboxtextalt.c
@@ -216,8 +216,6 @@ gtk_combo_box_text_alt_get_preferred_height_for_width(GtkWidget *widget,
     
     GtkRequisition min_size, nat_size;
     gtk_cell_renderer_get_preferred_size(cell, widget, &min_size, &nat_size);
-    gint cell_width, cell_height;
-    gtk_cell_renderer_get_fixed_size(cell, &cell_width, &cell_height);
     
     gint xpad, ypad;
     gtk_cell_renderer_get_padding(cell, &xpad, &ypad);

--- a/shoes/native/gtkcomboboxtextalt.h
+++ b/shoes/native/gtkcomboboxtextalt.h
@@ -26,7 +26,7 @@ typedef struct _GtkComboBoxText_AltClass {
 
 GType gtk_combo_box_text_alt_get_type(void) G_GNUC_CONST;
 //GtkWidget *gtk_combo_box_text_alt_new(void);
-GtkWidget *gtk_combo_box_text_alt_new(VALUE attribs);
+GtkWidget *gtk_combo_box_text_alt_new(VALUE attribs, int bottom_margin);
 
 G_END_DECLS
 


### PR DESCRIPTION
looks finally correct for list_box now
the alternate gtkcombobox needs bottom margin to calculate properly the height of the widget
this is done in gtk.c *shoes_native_list_box* method because it's easier there (we need the canvas parameter which is just there)

samples/simple-control-sizes.rb to test/compare 