### PR TITLE
list_box : 2 pixels were missing ... 

### DIFF
--- a/shoes/native/gtk.c
+++ b/shoes/native/gtk.c
@@ -1390,7 +1390,7 @@ shoes_native_list_box(VALUE self, shoes_canvas *canvas, shoes_place *place, VALU
 {
 #ifdef GTK3
   /*get bottom margin : following macro gives us bmargin (also lmargin,tmargin,rmargin)*/
-  ATTR_MARGINS(attr, 2, canvas);
+  ATTR_MARGINS(attr, 0, canvas);
   
   //SHOES_CONTROL_REF ref = gtk_combo_box_text_new();
   SHOES_CONTROL_REF ref = gtk_combo_box_text_alt_new(attr, bmargin);


### PR DESCRIPTION
present incarnation is 2 pixels bigger (in height and only in default height - ie no user :height provided-) than the gtk2 version but behave the same, not sure i can do better without subclassing the whole thing (combobox is pretty heavy)