### PR TITLE
video fix, synch with master, typo fix

### DIFF
--- a/make/linux/env.rb
+++ b/make/linux/env.rb
@@ -23,7 +23,7 @@ LINUX_CFLAGS << " -DDEBUG" if ENV['DEBUG']
 LINUX_CFLAGS << " -DSHOES_GTK -fPIC -shared"
 # Following line may need handcrafting
 LINUX_CFLAGS << " -I/usr/include/"
-LINUX_CFLAGS << " #{`pkg-config --cflags gtk+-3.0}`.strip}"
+LINUX_CFLAGS << " #{`pkg-config --cflags gtk+-3.0`.strip}"
 
 CC = "gcc"
 

--- a/shoes/native/gtk.c
+++ b/shoes/native/gtk.c
@@ -1268,7 +1268,7 @@ shoes_native_surface_new(VALUE attr)
 void
 shoes_native_surface_remove(shoes_canvas *canvas, SHOES_CONTROL_REF ref)
 {
-  gtk_container_remove(GTK_CONTAINER(canvas->slot->oscanvas), ref);
+  gtk_widget_destroy(ref);
 }
 
 /* doing this directly on control now

--- a/shoes/video/video.c
+++ b/shoes/video/video.c
@@ -251,8 +251,9 @@ VALUE shoes_video_remove(VALUE self) {
   shoes_canvas *canvas;
   Data_Get_Struct(self_t->parent, shoes_canvas, canvas);
 
-  shoes_canvas_remove_item(self_t->parent, self, 1, 0);
+  rb_ary_delete(canvas->contents, self);
   shoes_native_surface_remove(canvas, self_t->ref);
+  self_t->ref = NULL;
   shoes_canvas_repaint_all(self_t->parent);
 
   self_t = NULL;


### PR DESCRIPTION
apart from the small typo fix in linux/env.rb, compilation went fine and everything looks OK
(there is still some #if GTK3 in config.h and effect.c)

fixed some gtk warnings, native_surface (drawing_area in gtk) should just be simply destroyed, could you look please in cocoa.m, the **shoes_native_surface_remove**  is a stub, if it's ok, we might want to simplify that method to **shoes_native_surface_remove( SHOES_CONTROL_REF ref)**, getting rid of the unnecessary shoes_canvas *canvas parameter (also in windows.c, oops this is old stuff, sorry, should we get rid of that ?)  ?