### PR TITLE
better hidden check for avalaibility of drawable for vlc, tests Linux…

### DIFF
--- a/Tests/test_video_vlc.rb
+++ b/Tests/test_video_vlc.rb
@@ -7,51 +7,132 @@ require 'shoes/videoffi'
 Vlc.load_lib
 
 require 'video_vlc_01.rb'
-    
+
 Shoes.app title: "Testing Shoes video" do
-    VideoVlcTestBase.init self
+    
     TESTS = {
-        VideoVlcTest1 => ["Testing initialisation of video widget without a given path to a media\n",
-                        span("Run this first to ensure that video widget works at its bare minimum\n", 
-                            stroke: darkred),
-                        "Testing procedure to wait for Drawing Area to be ready for vlc to use it"],
-        VideoVlcTest2 => "Testing initialisation of video widget with a given path to a movie\n" \
-                        "relying on video track size if no widget or parent canvas dimensions provided", 
-        VideoVlcTest3 => "Testing audio facility", 
-        VideoVlcTest4 => "Testing media loading",
-        VideoVlcTest5 => "Passing vlc options to underlaying libvlc_new() C method"
+        VideoVlcTest0 => { desc: ["Most Basic unique Test : no path/url, no dimensions\n",
+                              span("Run this first to ensure that video widget works at its bare minimum",
+                              stroke: darkred)], 
+                           cont_args: {},
+                           widget_args: ['']
+                         },
+        VideoVlcTest1 => { desc: ["Iinitialisation of video widget without a given path to a media\n",
+                            "path= method \nvideo widget ", span("Container", weight: 'bold'), " dimensions given "],
+                           cont_args: {width: 30, height: 20},
+                           widget_args: ['', bg_color: yellow]
+                         },
+        VideoVlcTest2 => { desc: ["Iinitialisation of video widget without a given path to a media\n",
+                            "path= method \nvideo ", span("Widget", weight: 'bold'), " dimensions given "],
+                           cont_args: {},
+                           widget_args: ['', width: 25, height: 20]
+                         },
+        VideoVlcTest3 => { desc: ["Iinitialisation of video widget without a given path to a media\n",
+                            "path= method \nvideo ", span("Widget and Container", weight: 'bold'), " dimensions given "],
+                           cont_args: {width: 35, height: 20},
+                           widget_args: ['', width: 20, height: 20]
+                         },
+        VideoVlcTest4 => { desc: "no Dimensions provided, relying on video track dimensions",
+                           cont_args: {},
+                           widget_args: ['AnemicCinema1926marcelDuchampCut.mp4']
+                         },                 
+        VideoVlcTest5 => { desc: "Widget background color",
+                           cont_args: {width: 36, height: 21},
+                           widget_args: ['', bg_color: yellow ]
+                         },
+        VideoVlcTestAudio => { desc: "audio method",
+                               cont_args: {width: 35, height: 20},
+                               widget_args: ['indian.m4a', width: 350, height: 20]
+                             },                 
+        VideoVlcTest7 => { desc: "Passing vlc options to underlaying libvlc_new() C method",
+                           cont_args: {width: 36, height: 21},
+                           widget_args: ['AnemicCinema1926marcelDuchampCut.mp4', 
+                                          vlc_options: ["--no-xlib", "--no-video-title-show"] ]
+                         },
     }
-    # we must wait for shoes asynchronous drawing events to occur
-    @run_test = -> (suite) { Thread.new {Test::Unit::UI::Console::TestRunner.run(suite)}; puts '='*40 }
+    
     
     style(Shoes::Para, size: 10)
-    stack do
+    
+    build_test_gui = -> (t, details) do
+        # if we try to draw tests widgets in a non visible area, drawing events are not triggered and
+        # Test processing hangs (waits) - start event is not fired -
+        # So we create a sand_box at top of Shoes app and scroll back there if necessary to 
+        # make drawing events happening 
+        app.slot.scroll_top = 0
+        
+        @sand_box.append do
+            @cont = flow( **details[:cont_args] ) do
+                @vid = 
+                if t == VideoVlcTestAudio
+                    audio( *details[:widget_args] )
+                else
+                    video( *details[:widget_args] )
+                end
+            end
+        end
+        
+        # waiting for shoes asynchronous drawing events to occur.
+        @cont.start {
+            #an = animate(10) { |fr|
+            #if fr == 2
+                #an.stop
+                ## There could be only one console at a time (we can safely call it many times)
+                #Shoes.show_console
+                
+                Test::Unit::UI::Console::TestRunner.run(t.suite)
+                
+                puts "#{'='*40}\n\n"
+                @sand_box.clear { para "Next test !" }
+                @sand_box.start { @test_complete = true }
+                #an.remove; an = nil
+            #end
+            #}
+        }
+    end
+    
+    @top = stack do
         para "\t\tLaunches Shoes terminal to collect results of Tests"
         
-        flow margin: [0,0,0,10] do 
+        @sand_box = stack(height: 50) {}
+        
+        flow margin: [0,0,0,10] do
             button "run ALL Tests" do
-                # There could be only one console at a time (we can safely call it many times)
-                Shoes.show_console
-                Thread.new {
-                    tests = Test::Unit::TestSuite.new("All Tests")
-                    TESTS.each { |t,d| tests << t.suite }
-                    @run_test.call(tests)
-                }
+                
+                # We have to wait for each test to complete (asynchronous drawing)
+                @test_complete = true
+                tenum = TESTS.each_with_index
+                anm = animate(20) do
+                    if @test_complete
+                        @test_complete = false
+                        h,i = tenum.next
+                        build_test_gui.call(h[0], h[1])
+                    
+                        if i == TESTS.size-1
+                            anm.stop
+                            anm.remove; anm = nil
+                        end
+                    end
+                end
             end
+            
             para "  in order of appearance, top to bottom"
         end
         
-        TESTS.each do |t, desc|
-            flow do 
+        TESTS.each do |t, details|
+            flow do
                 button "run Test" do
-                    Shoes.show_console
-                    @run_test.call(t.suite)
+                    build_test_gui.call(t, details)
                 end
-                
-                para *(["#{t.to_s} : \n"] << desc)
-            end        
+
+                para *(["#{t.to_s} : \n"] << details[:desc])
+            end
         end
         
     end
+    
+    def cont; @cont end
+    def vid; @vid end
+    VideoVlcTestBase.init self
     
 end

--- a/Tests/video_vlc_01.rb
+++ b/Tests/video_vlc_01.rb
@@ -5,223 +5,235 @@ class VideoVlcTestBase < Test::Unit::TestCase
         def init(app)
             @@app = app
         end
-        #def startup; end
-        #def shutdown; end
+        def startup
+            @@mediav = "AnemicCinema1926marcelDuchampCut.mp4"
+            @@mediaa = "indian.m4a"
+            # a fake stream : not relying on internet's mood swings for the test
+            @@mediast = "file://#{File.expand_path('./AnemicCinema1926marcelDuchampCut.mp4')}"
+        end
+        
+        def shutdown
+            @@mediav = nil
+            @@mediaa = nil
+            @@mediast = nil
+        end
     end
-    
-    def setup
-        @started = false
+
+    def setup; end
+    def teardown; end
+end
+
+class VideoVlcTest0 < VideoVlcTestBase
+
+    description "no dimensions provided, no path/url, nothing to draw"
+    def test_video_noPath_noDim
+        
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        vidc = @@app.vid.instance_variable_get(:@video)
+        assert_true vidc.drawable_ready?
+        
+        vlci = @@app.vid.instance_variable_get(:@vlci)
+        assert_not_nil vlci
+        assert_instance_of Fiddle::Pointer, vlci
+        assert_false vlci.null?
+        
+        assert_equal 0, @@app.vid.width
     end
-    
-    def teardown
-        @cont.remove if @cont
-        @cont = nil
-        @vid = nil
-    end  
 end
 
 class VideoVlcTest1 < VideoVlcTestBase
     
-    description "no dimensions provided, no path/url, nothing to draw"
-    def test_video_noPath_noDim
-        @cont = @@app.flow do 
-            @vid = Shoes::VideoVlc.new( @@app, '' )
-        end.start { @started = true }
-        
-        ## First test! Let's see if widget is working at it's most basic level
-        ## don't wait here on start event, so in case of major failure
-        ## we're not stuck in an infinite loop
-        sleep 0.5
-        
-        assert_not_nil @vid
-        assert_instance_of Shoes::VideoVlc, @vid
-        vlci = @vid.instance_variable_get(:@vlci)
-        assert_not_nil vlci
-        assert_instance_of Fiddle::Pointer, vlci
-        assert_false vlci.null?
-        assert_equal 0, @vid.width
+    def test_slotDim_noPath
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        assert_equal 30, @@app.vid.width
     end
     
-    def test_video_noPath_slotDim
-        @cont = @@app.flow width: 300, height: 200, start: proc { @started = true }  do 
-            @vid = Shoes::VideoVlc.new( @@app, '')
-        end
+    def test_slotDim_movie
+        @@app.vid.path = @@mediav
         
-        while not @started do; end
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        assert_equal 30, @@app.vid.width
         
-        assert_true @cont.style[:started]
-        assert_instance_of Shoes::VideoVlc, @vid
-        assert_equal 300, @vid.width
+        assert_equal @@mediav, @@app.vid.path
+        assert_true @@app.vid.loaded
+        assert_true @@app.vid.have_video_track
+        assert_equal 640, @@app.vid.video_track_width
+        assert_equal 480, @@app.vid.video_track_height
+        assert_true @@app.vid.have_audio_track
     end
-     
-    def test_video_noPath_videoWidgetDim
-        @cont = @@app.flow do 
-            @vid = Shoes::VideoVlc.new( @@app, '', width: 250, height: 200 )
-        end.start { @started = true }
+    
+    def test_slotDim_audio
+        @@app.vid.path = @@mediaa
         
-        while not @started do; end
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        assert_equal 30, @@app.vid.width
         
-        assert_true @cont.style[:started]
-        assert_instance_of Shoes::VideoVlc, @vid
-        assert_equal 250, @vid.width
+        assert_equal @@mediaa, @@app.vid.path
+        assert_true @@app.vid.loaded
+        assert_true @@app.vid.have_audio_track
+        assert_nil @@app.vid.have_video_track
+        assert_nil @@app.vid.video_track_width
+        assert_nil @@app.vid.video_track_height
     end
-     
-    def test_video_noPath_slotVideoWidgetDim
-        @cont = @@app.flow width: 300, height: 200 do 
-            @vid = Shoes::VideoVlc.new( @@app, '', {width: 250, height: 200} )
-        end.start { @started = true }
+    
+    def test_slotDim_stream
+        @@app.vid.path = @@mediast
         
-        while not @started do; end
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        assert_equal 30, @@app.vid.width
         
-        assert_true @cont.style[:started]
-        assert_instance_of Shoes::VideoVlc, @vid
-        assert_equal 250, @vid.width
+        assert_equal @@mediast, @@app.vid.path
+        assert_true @@app.vid.loaded
     end
 end
 
 class VideoVlcTest2 < VideoVlcTestBase
-
-    def setup
-        super
-        @movie = "AnemicCinema1926marcelDuchampCut.mp4"
+    
+    def test_widgetDim_noPath
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        assert_equal 25, @@app.vid.width
     end
     
-    description "no dimensions provided, relying on video track size"
-    def test_video_path_noDim
-        @cont = @@app.flow do 
-            @vid = Shoes::VideoVlc.new( @@app, @movie )
-        end.start { @started = true }
+    def test_widgetDim_movie
+        @@app.vid.path = @@mediav
         
-        while not @started do; end
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        assert_equal 25, @@app.vid.width
         
-        assert_true @cont.style[:started]
-        assert_instance_of Shoes::VideoVlc, @vid
-        assert_equal 640, @vid.width
-        assert_equal 480, @vid.height
+        assert_equal @@mediav, @@app.vid.path
+        assert_true @@app.vid.loaded
+        assert_true @@app.vid.have_video_track
+        assert_equal 640, @@app.vid.video_track_width
+        assert_equal 480, @@app.vid.video_track_height
+        assert_true @@app.vid.have_audio_track
     end
     
-    def test_video_path_slotDim
-        @cont = @@app.flow width: 300, height: 200  do 
-            @vid = Shoes::VideoVlc.new( @@app, @movie )
-        end.start { @started = true }
+    def test_widgetDim_audio
+        @@app.vid.path = @@mediaa
         
-        while not @started do; end
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        assert_equal 25, @@app.vid.width
         
-        assert_true @cont.style[:started]
-        assert_instance_of Shoes::VideoVlc, @vid
-        assert_equal 300, @vid.width
+        assert_equal @@mediaa, @@app.vid.path
+        assert_true @@app.vid.loaded
+        assert_true @@app.vid.have_audio_track
+        assert_nil @@app.vid.have_video_track
+        assert_nil @@app.vid.video_track_width
+        assert_nil @@app.vid.video_track_height
     end
-     
-    def test_video_path_videoWidgetDim
-        @cont = @@app.flow do 
-            @vid = Shoes::VideoVlc.new( @@app, @movie, width: 250, height: 200 )
-        end.start { @started = true }
+    
+    def test_widgetDim_stream
+        @@app.vid.path = @@mediast
         
-        while not @started do; end
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        assert_equal 25, @@app.vid.width
         
-        assert_true @cont.style[:started]
-        assert_instance_of Shoes::VideoVlc, @vid
-        assert_equal 250, @vid.width
-    end
-     
-    def test_video_path_slotVideoWidgetDim
-        @cont = @@app.flow width: 300, height: 200 do 
-            @vid = Shoes::VideoVlc.new( @@app, @movie, width: 250, height: 200 )
-        end.start { @started = true }
-        
-        while not @started do; end
-        
-        assert_true @cont.style[:started]
-        assert_instance_of Shoes::VideoVlc, @vid
-        assert_equal 250, @vid.width
+        assert_equal @@mediast, @@app.vid.path
+        assert_true @@app.vid.loaded
     end
 end
 
 class VideoVlcTest3 < VideoVlcTestBase
-    def setup
-        super
-        @audio = "indian.m4a"
+    
+    def test_slotDim_widgetDim_noPath
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        assert_equal 20, @@app.vid.width
     end
     
-    def test_audio
-        @cont = @@app.flow width: 300, height: 200 do 
-            @vid = Shoes::VideoVlc.new( @@app, @audio, width: 0, height: 0, hidden: true )
-        end.start { @started = true }
+    def test_slotDim_widgetDim_movie
+        @@app.vid.path = @@mediav
         
-        while not @started do; end
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        assert_equal 20, @@app.vid.width
         
-        assert_true @cont.style[:started]
-        assert_instance_of Shoes::VideoVlc, @vid
-        assert_equal 0, @vid.width
-        assert_true @vid.style[:hidden]
+        assert_equal @@mediav, @@app.vid.path
+        assert_true @@app.vid.loaded
+        assert_true @@app.vid.have_video_track
+        assert_equal 640, @@app.vid.video_track_width
+        assert_equal 480, @@app.vid.video_track_height
+        assert_true @@app.vid.have_audio_track
     end
     
-end
-
-class VideoVlcTest4 < VideoVlcTestBase
-    def setup
-        super
-        @mediav = "AnemicCinema1926marcelDuchampCut.mp4"
-        @mediaa = "indian.m4a"
-        # not relying on internet's mood swings for the test
-        fakestream = "file://#{File.expand_path('./AnemicCinema1926marcelDuchampCut.mp4')}"
-        @medias = fakestream
+    def test_slotDim_widgetDim_audio
+        @@app.vid.path = @@mediaa
+        
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        assert_equal 20, @@app.vid.width
+        
+        assert_equal @@mediaa, @@app.vid.path
+        assert_true @@app.vid.loaded
+        assert_true @@app.vid.have_audio_track
+        assert_nil @@app.vid.have_video_track
+        assert_nil @@app.vid.video_track_width
+        assert_nil @@app.vid.video_track_height
     end
     
-    def test_load_media
-        @cont = @@app.flow width: 300, height: 200 do 
-            @vid = Shoes::VideoVlc.new( @@app, '' )
-        end.start { @started = true }
-        while not @started do; end
+    def test_slotDim_widgetDim_stream
+        @@app.vid.path = @@mediast
         
-        @vid.path = @mediav
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        assert_equal 20, @@app.vid.width
         
-        assert_equal @mediav, @vid.path
-        assert_true @vid.loaded
-        assert_true @vid.have_video_track
-        assert_equal 640, @vid.video_track_width
-        assert_equal 480, @vid.video_track_height
-        assert_true @vid.have_audio_track
-        
-        @vid.path = @mediaa
-        
-        assert_equal @mediaa, @vid.path
-        assert_true @vid.loaded
-        assert_nil @vid.have_video_track
-        assert_true @vid.have_audio_track
-        
-        @vid.path = ""
-        assert_nil @vid.loaded
-        assert_nil @vid.have_video_track
-        assert_nil @vid.have_audio_track
-        
-        @vid.path = @medias
-        assert_equal @medias, @vid.path
-        assert_true @vid.loaded
+        assert_equal @@mediast, @@app.vid.path
+        assert_true @@app.vid.loaded
     end
 end
 
-class VideoVlcTest5 < VideoVlcTestBase
-    def setup
-        super
-        @media = "AnemicCinema1926marcelDuchampCut.mp4"
-    end
-    
-    def test_libvlc_options
-        vid = nil
-        @cont = @@app.flow width: 300, height: 200 do 
-            vid = Shoes::VideoVlc.new( @@app, @media, bg_color: rgb(20,250,20),
-                                        vlc_options: ["--no-xlib", "--no-video-title-show"] )
-        end.start { @started = true }
-        while not @started do; end
+class VideoVlcTest4  < VideoVlcTestBase
+    def test_videoTrackDim
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
         
-        assert_not_nil vid
-        vlci = vid.instance_variable_get(:@vlci)
+        assert_equal 640, @@app.vid.width
+        assert_equal 480, @@app.vid.height
+    end
+end
+
+class VideoVlcTest5  < VideoVlcTestBase
+    def test_backgroundColor
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        assert_equal 36, @@app.vid.width
+        
+        assert_equal 255, @@app.vid.style[:bg_color].red
+        assert_equal 255, @@app.vid.style[:bg_color].green
+        assert_equal 0, @@app.vid.style[:bg_color].blue
+    end
+end
+
+class VideoVlcTestAudio  < VideoVlcTestBase
+    def test_audioMethod
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        
+        assert_equal 0, @@app.vid.width
+        assert_true @@app.vid.style[:hidden]
+    end
+end
+
+class VideoVlcTest7  < VideoVlcTestBase
+    def test_libvlcOptions
+        assert_not_nil @@app.vid
+        vlci = @@app.vid.instance_variable_get(:@vlci)
         assert_not_nil vlci
         assert_instance_of Fiddle::Pointer, vlci
         assert_false vlci.null?
-        assert_false vid.style.include?(:vlc_options)
+        assert_false @@app.vid.style.include?(:vlc_options)
     end
 end
+
 
 

--- a/shoes/canvas.c
+++ b/shoes/canvas.c
@@ -1849,7 +1849,7 @@ shoes_canvas_send_start(VALUE self)
       if (canvas->stage == CANVAS_PAINT) {
         canvas->stage = CANVAS_STARTED;
         ((shoes_canvas *)canvas->slot->owner)->stage = CANVAS_STARTED;
-        g_timeout_add_full(G_PRIORITY_DEFAULT, 1, start_wait, (gpointer)self, NULL);
+        g_timeout_add_full(G_PRIORITY_HIGH, 1, start_wait, (gpointer)self, NULL);
       } else {
 //        canvas->stage = CANVAS_STARTED;
 //        ((shoes_canvas *)canvas->slot->owner)->stage = CANVAS_STARTED;
@@ -1861,12 +1861,6 @@ shoes_canvas_send_start(VALUE self)
       ((shoes_canvas *)canvas->slot->owner)->stage = CANVAS_STARTED;
     }
   }
-  
-  /* internal private attribute used in fiddle-video protocol 
-     letting Shoes know when drawable is avalaible, so we don't hijack start event
-   */ 
-  shoes_hash_set(canvas->attr, rb_intern("started"), Qtrue);
-
 }
 
 static void

--- a/shoes/native.h
+++ b/shoes/native.h
@@ -69,7 +69,7 @@ void shoes_native_control_focus(SHOES_CONTROL_REF);
 void shoes_native_control_state(SHOES_CONTROL_REF, SHOES_BOOL, SHOES_BOOL);
 void shoes_native_control_remove(SHOES_CONTROL_REF, shoes_canvas *);
 void shoes_native_control_free(SHOES_CONTROL_REF);
-SHOES_CONTROL_REF shoes_native_surface_new(VALUE);
+SHOES_CONTROL_REF shoes_native_surface_new(VALUE, VALUE);
 unsigned long shoes_native_surface_get_window_handle(SHOES_CONTROL_REF);
 void shoes_native_surface_position(SHOES_SURFACE_REF, shoes_place *,
   VALUE, shoes_canvas *, shoes_place *);

--- a/shoes/native/cocoa.m
+++ b/shoes/native/cocoa.m
@@ -1290,14 +1290,14 @@ shoes_native_surface_new(shoes_canvas *canvas, VALUE self, shoes_place *place)
 */
 
 SHOES_CONTROL_REF
-shoes_native_surface_new(VALUE attr)
+shoes_native_surface_new(VALUE attr, VALUE video)
 {
   // Create an NSView
   int w = NUM2INT(ATTR(attr, width));
   int h = NUM2INT(ATTR(attr, height));
   NSRect rect = NSMakeRect(0, 0, w, h);
   NSView *nativeView = [[NSView alloc] initWithFrame: rect];
-  // Paint It Black
+  // Paint It Black  Hot Stuff !
   [nativeView setWantsLayer:YES];
   [nativeView.layer setBackgroundColor:[[NSColor blackColor] CGColor]];
   return (SHOES_CONTROL_REF)nativeView;

--- a/shoes/video/video.h
+++ b/shoes/video/video.h
@@ -15,6 +15,7 @@ typedef struct {
   VALUE attr;
   shoes_place place;
   SHOES_CONTROL_REF ref;
+  int realized;
   SHOES_SLOT_OS *slot;
   int init;
 } shoes_video;
@@ -31,6 +32,7 @@ VALUE shoes_video_new(VALUE, VALUE);
 VALUE shoes_video_draw(VALUE, VALUE, VALUE);
 VALUE shoes_video_get_parent(VALUE);
 VALUE shoes_video_get_drawable(VALUE);
+VALUE shoes_video_get_realized(VALUE);
 VALUE shoes_video_remove(VALUE);
 VALUE shoes_video_show(VALUE);
 VALUE shoes_video_hide(VALUE);


### PR DESCRIPTION
…/Windows ok

Now we don't check for attribute **:started**, accessible to everyone, to be true but for a hidden method **drawable_realized?** which reports true when surface (drawing area in gtk) is "realized" hence ready for vlc to connect to, also the method being specific to video widget it is not fired on every drawing of every canvas !
Still need to accommodate in cocoa if possible, (shoes_native_surface_new is ready for change : new argument added ) + connect the surface to the cocoa equivalent "realize" signal

Isolated gui stuff in tests, WIP

I have threading issues (i think) with video widget, Windows and Linux (Tests made them obvious !)
Investigating ... any clue is welcome ... lots of random memory corruption happening at random places
(added some release methods from libvlc, not related it seems)