### PR TITLE
fix bug garbage collector trying to free already freed pointer in vlc…

### DIFF
--- a/Tests/test_video_vlc.rb
+++ b/Tests/test_video_vlc.rb
@@ -40,15 +40,16 @@ Shoes.app title: "Testing Shoes video" do
                            cont_args: {width: 36, height: 21},
                            widget_args: ['', bg_color: yellow ]
                          },
-        VideoVlcTestAudio => { desc: "audio method",
-                               cont_args: {width: 35, height: 20},
-                               widget_args: ['indian.m4a', width: 350, height: 20]
-                             },                 
-        VideoVlcTest7 => { desc: "Passing vlc options to underlaying libvlc_new() C method",
+        VideoVlcTest6 => { desc: "Passing vlc options to underlaying libvlc_new() C method",
                            cont_args: {width: 36, height: 21},
                            widget_args: ['AnemicCinema1926marcelDuchampCut.mp4', 
                                           vlc_options: ["--no-xlib", "--no-video-title-show"] ]
-                         },
+                         },                 
+        VideoVlcTestAudio => { desc: "audio method + volume, volume= methods",
+                               cont_args: {width: 35, height: 20},
+                               widget_args: ['indian.m4a', width: 350, height: 20]
+                             },                 
+         
     }
     
     
@@ -74,20 +75,14 @@ Shoes.app title: "Testing Shoes video" do
         
         # waiting for shoes asynchronous drawing events to occur.
         @cont.start {
-            #an = animate(10) { |fr|
-            #if fr == 2
-                #an.stop
-                ## There could be only one console at a time (we can safely call it many times)
-                #Shoes.show_console
-                
-                Test::Unit::UI::Console::TestRunner.run(t.suite)
-                
-                puts "#{'='*40}\n\n"
-                @sand_box.clear { para "Next test !" }
-                @sand_box.start { @test_complete = true }
-                #an.remove; an = nil
-            #end
-            #}
+            ## There could be only one console at a time (we can safely call it many times)
+            #Shoes.show_console
+            
+            Test::Unit::UI::Console::TestRunner.run(t.suite)
+            
+            puts "#{'='*40}\n\n"
+            @sand_box.clear
+            @sand_box.start { @test_complete = true }
         }
     end
     

--- a/Tests/video_vlc_01.rb
+++ b/Tests/video_vlc_01.rb
@@ -214,17 +214,7 @@ class VideoVlcTest5  < VideoVlcTestBase
     end
 end
 
-class VideoVlcTestAudio  < VideoVlcTestBase
-    def test_audioMethod
-        assert_not_nil @@app.vid
-        assert_instance_of Shoes::VideoVlc, @@app.vid
-        
-        assert_equal 0, @@app.vid.width
-        assert_true @@app.vid.style[:hidden]
-    end
-end
-
-class VideoVlcTest7  < VideoVlcTestBase
+class VideoVlcTest6  < VideoVlcTestBase
     def test_libvlcOptions
         assert_not_nil @@app.vid
         vlci = @@app.vid.instance_variable_get(:@vlci)
@@ -235,5 +225,18 @@ class VideoVlcTest7  < VideoVlcTestBase
     end
 end
 
+class VideoVlcTestAudio  < VideoVlcTestBase
+    def test_audioMethod
+        assert_not_nil @@app.vid
+        assert_instance_of Shoes::VideoVlc, @@app.vid
+        
+        assert_equal 0, @@app.vid.width
+        assert_true @@app.vid.style[:hidden]
+        
+        assert_equal 85, @@app.vid.volume
+        @@app.vid.volume = 72
+        assert_equal 72, @@app.vid.volume
+    end
+end
 
 

--- a/samples/expert-video-player.rb
+++ b/samples/expert-video-player.rb
@@ -47,16 +47,8 @@ class Shoes::Knob < Shoes::Widget
     
     def tint=(color)
         @tint = color
-        @needle.remove
-        @ovl.remove
-        
-        @canvas.append do
-            strokewidth 2
-            stroke @tint
-            fill @tint
-            @ovl = oval :left => @cx - (3*@size), :top => @cy - (3*@size), :radius => (3*@size)
-            @needle = radial_line 225 + ((270.0 / @range.end) * @fraction), 0..(12*@size)
-        end
+        @ovl.style(fill: @tint, stroke: @tint)
+        @needle.style(fill: @tint, stroke: @tint)
     end
     
     def ticks; @range.end / @tick end

--- a/shoes/canvas.c
+++ b/shoes/canvas.c
@@ -1808,6 +1808,8 @@ shoes_canvas_start(int argc, VALUE *argv, VALUE self)
     // they are the same when canvas has a :height 
     canvas->stage = CANVAS_PAINT;
     ((shoes_canvas *)canvas->slot->owner)->stage = CANVAS_PAINT;
+//    printf("app nesting size = : %ld\n", RARRAY_LEN(canvas->app->nesting));
+//    printf("same canvas ? : %s\n", (canvas == ((shoes_canvas *)canvas->slot->owner)) ? "yes" : "no");
     
     return self;
   }


### PR DESCRIPTION
… tracks processing

While hunting for the bug, i tried this :
https://github.com/passenger94/shoes3/blob/af959324b2b6fc6b6733e8e06aa44c1602f43df1/lib/shoes/videoffi.rb#L258 
https://github.com/passenger94/shoes3/blob/af959324b2b6fc6b6733e8e06aa44c1602f43df1/lib/shoes/videoffi.rb#L338
i left those in case we want later to add specific platform/version symbols, just checking if it works 
(could you,please, check if OSX complains ?)
we can erase them or keep them, thoughts ?