### PR TITLE
adds a finish event to Shoes::App

### DIFF
--- a/shoes/app.c
+++ b/shoes/app.c
@@ -99,6 +99,9 @@ shoes_app_clear(shoes_app *app)
 int
 shoes_app_remove(shoes_app *app)
 {
+  // gives a chance to cleanup before quit
+  shoes_canvas_send_finish(app->canvas);
+  
   shoes_app_clear(app);
   rb_ary_delete(shoes_world->apps, app->self);
   return (RARRAY_LEN(shoes_world->apps) == 0);

--- a/shoes/canvas.c
+++ b/shoes/canvas.c
@@ -36,7 +36,8 @@ const double SHOES_RAD2PI = 0.01745329251994329577;
 //const char *dialog_title_says = USTR("Shoes says:");
 
 static void shoes_canvas_send_start(VALUE);
-static void shoes_canvas_send_finish(VALUE);
+// made it public to hook to an app quit event
+//static void shoes_canvas_send_finish(VALUE);
 
 shoes_transform *
 shoes_transform_new(shoes_transform *o)
@@ -1856,7 +1857,7 @@ shoes_canvas_send_start(VALUE self)
   }
 }
 
-static void
+void
 shoes_canvas_send_finish(VALUE self)
 {
   shoes_canvas *canvas;

--- a/shoes/canvas.h
+++ b/shoes/canvas.h
@@ -500,6 +500,7 @@ void shoes_canvas_wheel_way(shoes_canvas *, ID);
 void shoes_canvas_send_keydown(VALUE, VALUE);
 void shoes_canvas_send_keypress(VALUE, VALUE);
 void shoes_canvas_send_keyup(VALUE, VALUE);
+void shoes_canvas_send_finish(VALUE);
 VALUE shoes_canvas_get_cursor(VALUE);
 VALUE shoes_canvas_set_cursor(VALUE, VALUE);
 VALUE shoes_canvas_get_clipboard(VALUE);


### PR DESCRIPTION
Sometimes we need to make sure some cleanup is done before app exits
i hooked the **app.slot** "canvas finish event" (was private) to the **shoes_app_remove** call
it happens whenever a Shoes app quit, be it the main or window, dialog